### PR TITLE
Register rules as if they only affect one title

### DIFF
--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -39,10 +39,10 @@ def write_layers(client, only_title, only_part):
             client.layer(layer_name, doc_type, doc_id).write(layer)
 
 
-def transform_notice(notice_xml):
+def transform_notice(notice_xml, only_title):
     """The API has a different format for notices than the local XML. We'll
     need to convert and add appropriate fields"""
-    as_dict = notice_xml.as_dict()
+    as_dict = notice_xml.as_dict(title=only_title)
     as_dict['versions'] = {}
     for cfr_title, cfr_part in notice_xml.cfr_ref_pairs:
         version_dir = entry.Version(cfr_title, cfr_part)
@@ -74,7 +74,7 @@ def write_notices(client, only_title, only_part):
         part_match = only_part is None or only_part in cfr_parts
         if title_match and part_match:
             client.notice(notice_entry.path[-1]).write(
-                transform_notice(notice_xml))
+                transform_notice(notice_xml, only_title))
 
 
 def write_diffs(client, only_title, only_part):

--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -345,6 +345,9 @@ class NoticeXML(XMLWrapper):
         except:             # noqa
             logger.error('Unable to fetch amendments for %s', self.version_id)
             return []
+        # if len(amendments) < 1:
+        #     raise Exception('Unable to fetch amendments for %s', self.version_id)
+
         return amendments
 
     @property
@@ -397,11 +400,14 @@ class NoticeXML(XMLWrapper):
     start_page = _root_property('fr-start-page', int)
     end_page = _root_property('fr-end-page', int)
 
-    def as_dict(self):
+    def as_dict(self, title=None):
         """We use JSON to represent notices in the API. This converts the
         relevant data into a dictionary to get one step closer. Unfortunately,
         that design assumes a single cfr_part"""
-        cfr_ref = self.cfr_refs[0]
+        cfr_ref = None
+        for ref in self.cfr_refs:
+            if ref.title == title:
+                cfr_ref = ref
         notice = {'amendments': self.amendments,
                   'cfr_parts': [str(part) for part in cfr_ref.parts],
                   'cfr_title': cfr_ref.title,

--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -345,9 +345,6 @@ class NoticeXML(XMLWrapper):
         except:             # noqa
             logger.error('Unable to fetch amendments for %s', self.version_id)
             return []
-        # if len(amendments) < 1:
-        #     raise Exception('Unable to fetch amendments for %s', self.version_id)
-
         return amendments
 
     @property


### PR DESCRIPTION
Before this an arbitrary title that the rule affected was used. This caused rules/notices to be ignored that should have been used.